### PR TITLE
Separate present with interaction path and present with interaction

### DIFF
--- a/include/chemical-ecology/RecordedCommunitySummarizer.hpp
+++ b/include/chemical-ecology/RecordedCommunitySummarizer.hpp
@@ -181,7 +181,7 @@ public:
 
       bool interacts = false;
       for (size_t other_id : subcommunity) {
-        // if (!summary.present[other_id]) continue; // <- This line wasn't in the original logic, but otherwise, everything will be counted as present with interactions
+        if (!summary.present[other_id]) continue; // <- This line wasn't in the original logic, but otherwise, everything will be counted as present with interactions
         // indirect + direct interactions
         interacts = community_structure.SpeciesInteractsWith(species_id, other_id);
         if (interacts) break;


### PR DESCRIPTION
- Switched PWIP summarizers back to filtering based on whether a species is present with a valid interaction pathway to another present species
- Added PWINT summarizers that summarize based on whether a species is present and has an interaction (direct or indirect) with another present species 

If this is not the implementation that y'all are envisioning, go reject this pull request! Just needed to get something in a state for some experiments. 